### PR TITLE
Use biblatex and biber instead of bibtex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ dt.log
 dt.bbl
 dt.blg
 dt.toc
+dt.out
 thesis.pdf
 dt.synctex.gz
 dt.pdf

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ dt.out
 thesis.pdf
 dt.synctex.gz
 dt.pdf
+dt.bcf
+dt.run.xml

--- a/Makefile
+++ b/Makefile
@@ -14,4 +14,4 @@ pdf: dt.tex di.bib
 	fi
 
 clean:
-	rm abbreviations_sorted.tex thesis.pdf dt.toc dt.log dt.blg dt.bbl dt.aux
+	rm -f abbreviations_sorted.tex thesis.pdf dt.toc dt.log dt.blg dt.bbl dt.aux dt.out

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 pdf: dt.tex di.bib
 	@cat abbreviations.tex |sort > abbreviations_sorted.tex	
 	pdflatex dt.tex
-	bibtex dt
+	biber dt
 	pdflatex dt.tex
 	pdflatex dt.tex
 
@@ -14,4 +14,4 @@ pdf: dt.tex di.bib
 	fi
 
 clean:
-	rm -f abbreviations_sorted.tex thesis.pdf dt.toc dt.log dt.blg dt.bbl dt.aux dt.out
+	rm -f abbreviations_sorted.tex thesis.pdf dt.toc dt.log dt.blg dt.bbl dt.aux dt.out dt.bcf dt.run.xml

--- a/dt.tex
+++ b/dt.tex
@@ -24,6 +24,8 @@
 \usepackage{multirow}
 \usepackage{amsfonts}
 \usepackage{xcolor}
+\usepackage[style=ieee, urldate=iso8601, date=iso8601, backend=biber]{biblatex}
+\addbibresource{di.bib}
 \tolerance=500
 
 %\usepackage[a4paper,margin=2.5cm,dvips]{geometry}
@@ -132,6 +134,5 @@ The template was updated during the summer of 2013 by Juha Kylmänen.
 \chapter{Conclusion}
 \input{conclusion}  % ./conclusion.tex
 
-\bibliographystyle{di}
-\bibliography{di}
+\printbibliography[title=REFERENCES, heading=bibnumbered]
 \end{document}

--- a/dt.tex
+++ b/dt.tex
@@ -5,7 +5,7 @@
 %
 
 \documentclass[a4paper, 12pt,titlepage]{dithesis}
-\usepackage[english,finnish]{babel}
+\usepackage[english,australian,finnish]{babel}
 \usepackage[utf8]{inputenc}
 \usepackage[T1]{fontenc}  
 \usepackage{times}
@@ -134,5 +134,7 @@ The template was updated during the summer of 2013 by Juha Kylmänen.
 \chapter{Conclusion}
 \input{conclusion}  % ./conclusion.tex
 
+% Use Australian locale in bibliography to change the date format to Day Month Year.
+\selectlanguage{australian}
 \printbibliography[title=REFERENCES, heading=bibnumbered]
 \end{document}

--- a/dt.tex
+++ b/dt.tex
@@ -25,6 +25,10 @@
 \usepackage{amsfonts}
 \usepackage{xcolor}
 \usepackage[style=ieee, minnames=1, maxnames=2, urldate=long]{biblatex}
+% Fix “visited on” string to “Accessed:” in urldate
+\DefineBibliographyStrings{australian}{%
+      urlseen = {Accessed:},
+}
 \addbibresource{di.bib}
 \tolerance=500
 

--- a/dt.tex
+++ b/dt.tex
@@ -24,7 +24,7 @@
 \usepackage{multirow}
 \usepackage{amsfonts}
 \usepackage{xcolor}
-\usepackage[style=ieee, urldate=iso8601, date=iso8601, backend=biber]{biblatex}
+\usepackage[style=ieee, minnames=1, maxnames=2, urldate=long]{biblatex}
 \addbibresource{di.bib}
 \tolerance=500
 

--- a/dt.tex
+++ b/dt.tex
@@ -24,7 +24,7 @@
 \usepackage{multirow}
 \usepackage{amsfonts}
 \usepackage{xcolor}
-\usepackage[style=ieee, minnames=1, maxnames=2, urldate=long]{biblatex}
+\usepackage[style=ieee, minnames=1, maxnames=2, urldate=long, dashed=false]{biblatex}
 % Fix “visited on” string to “Accessed:” in urldate
 \DefineBibliographyStrings{australian}{%
       urlseen = {Accessed:},


### PR DESCRIPTION
Biblatex + biber combo gives much more freedom in styling the reference
list, like urldate fields (nice autogenerated "visited on" info) and IEEE style out of the box, which follows IEEE citation guide much more accurately than the bibtex version.